### PR TITLE
Allow coordinates with more than two elements

### DIFF
--- a/GeoJSONSerialization/GeoJSONSerialization.m
+++ b/GeoJSONSerialization/GeoJSONSerialization.m
@@ -35,10 +35,10 @@ static inline double CLLocationCoordinateNormalizedLongitude(double latitude) {
 }
 
 static inline CLLocationCoordinate2D CLLocationCoordinateFromCoordinates(NSArray *coordinates) {
-    NSCParameterAssert(coordinates && [coordinates count] == 2);
+    NSCParameterAssert(coordinates && [coordinates count] >= 2);
 
     NSNumber *longitude = [coordinates firstObject];
-    NSNumber *latitude = [coordinates lastObject];
+    NSNumber *latitude = [coordinates count] > 1 ? [coordinates objectAtIndex:1] : nil;
 
     return CLLocationCoordinate2DMake(CLLocationCoordinateNormalizedLatitude([latitude doubleValue]), CLLocationCoordinateNormalizedLongitude([longitude doubleValue]));
 }


### PR DESCRIPTION
Thanks for this library.

I have a [data set](http://daten.berlin.de/datensaetze/geometrien-der-ortsteile-von-berlin-stand-072012) with coordinates that have three elements:

```
                "coordinates": [
                    [
                        [
                            13.37362286299343,
                            52.52791796547066,
                            0
                        ],
```

When reading this data set with `shapesFromGeoJSONFeatureCollection:error:`, the current code  causes an assert because `CLLocationCoordinateFromCoordinates()` expects exactly two coordinates.

The GeoJSON spec allows for more than two elements, see [2.1.1. Positions](http://geojson.org/geojson-spec.html#positions). For this reason, I modified the code to ignore additional elements.

Please have a look, thanks.
