### PR TITLE
Flatten the output shape array.

### DIFF
--- a/GeoJSONSerialization/GeoJSONSerialization.m
+++ b/GeoJSONSerialization/GeoJSONSerialization.m
@@ -231,7 +231,11 @@ static NSArray * MKShapesFromGeoJSONFeatureCollection(NSDictionary *featureColle
     for (NSDictionary *feature in featureCollection[@"features"]) {
         id shape = MKShapeFromGeoJSONFeature(feature);
         if (shape) {
-            [mutableShapes addObject:shape];
+            if ([shape isKindOfClass:[NSArray class]]) {
+                [mutableShapes addObjectsFromArray:shape];
+            } else {
+                [mutableShapes addObject:shape];
+            }
         }
     }
     


### PR DESCRIPTION
Flatten the output of MultiPoint, MultiLineString and MultiPolygon so that the output array only contains MKShape classes.

I did it this way because the reverse procedure (MKShape -> GeoJSON) does not support generating Multi\* features, and the documentation implies that the output array will just be a flat collection of MKShape classes.
