### PR TITLE
Create sample implementation of GeoJSON geometry parsing

### DIFF
--- a/GeoJSONSerialization/GeoJSONSerialization.h
+++ b/GeoJSONSerialization/GeoJSONSerialization.h
@@ -31,6 +31,12 @@
 /// @name Creating MKShape objects from GeoJSON
 
 /**
+
+ */
++ (MKShape *)shapeFromGeoJSONGeometry:(NSDictionary *)geometry
+                                error:(NSError * __autoreleasing *)error;
+
+/**
  
  */
 + (MKShape *)shapeFromGeoJSONFeature:(NSDictionary *)feature


### PR DESCRIPTION
I write a fun little app called [Image Retweever](http://bit.ly/ImageRetweeverApp). My users have asked me to integrate maps into my displays. The map data comes from Twitter as GeoJSON geometry embedded in a tweet or place. [Twitter's reverse geocoding](https://dev.twitter.com/rest/reference/get/geo/reverse_geocode) is a good place to see this in action. Both points and polygons exist in the reply JSON.

To support the above goal, I have made a simple, incomplete implementation. If there is interest, I am happy to complete it to support all of the geometry objects.

Anon,
Andrew
