### PR TITLE
Fixes missing .pch build error

### DIFF
--- a/Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example.xcodeproj/project.pbxproj
@@ -430,7 +430,7 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "iOS Example/iOS Example-Prefix.pch";
+				GCC_PREFIX_HEADER = "iOS Example/Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -452,7 +452,7 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "iOS Example/iOS Example-Prefix.pch";
+				GCC_PREFIX_HEADER = "iOS Example/Prefix.pch";
 				INFOPLIST_FILE = "iOS ExampleTests/iOS ExampleTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";


### PR DESCRIPTION
This fixes the issue of the iOS target not building on Xcode 6.3
because of the iOS test target is pointing to an non-existent .pch file.
