### PR TITLE
Implemented parsing of altitude data for points and polylines

### DIFF
--- a/GeoJSONSerialization.xcworkspace/contents.xcworkspacedata
+++ b/GeoJSONSerialization.xcworkspace/contents.xcworkspacedata
@@ -10,6 +10,18 @@
       <FileRef
          location = "group:GeoJSONSerialization.m">
       </FileRef>
+      <FileRef
+         location = "group:MKPointAnnotation+altitude.h">
+      </FileRef>
+      <FileRef
+         location = "group:MKPointAnnotation+altitude.m">
+      </FileRef>
+      <FileRef
+         location = "group:MKPolyline+Altitudes.h">
+      </FileRef>
+      <FileRef
+         location = "group:MKPolyline+Altitudes.m">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:Example/iOS Example.xcodeproj">

--- a/GeoJSONSerialization/GeoJSONSerialization.h
+++ b/GeoJSONSerialization/GeoJSONSerialization.h
@@ -23,6 +23,8 @@
 #import <Foundation/Foundation.h>
 #import <MapKit/MapKit.h>
 
+#define kInvalidAltitude DBL_MAX
+
 /**
  
  */

--- a/GeoJSONSerialization/MKPointAnnotation+altitude.h
+++ b/GeoJSONSerialization/MKPointAnnotation+altitude.h
@@ -1,0 +1,29 @@
+// MKPointAnnotation+altitude.h
+//
+// Copyright (c) 2016 Michele Noberasco
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <MapKit/MapKit.h>
+
+@interface MKPointAnnotation (Altitude)
+
+@property (nonatomic, retain) NSNumber *altitude;
+
+@end

--- a/GeoJSONSerialization/MKPointAnnotation+altitude.m
+++ b/GeoJSONSerialization/MKPointAnnotation+altitude.m
@@ -1,0 +1,39 @@
+// MKPointAnnotation+altitude.m
+//
+// Copyright (c) 2016 Michele Noberasco
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <objc/runtime.h>
+
+#import "MKPointAnnotation+altitude.h"
+
+@implementation MKPointAnnotation (Altitude)
+
+static char altitudeKey;
+
+- (NSNumber *)altitude {
+  return objc_getAssociatedObject(self, &altitudeKey);
+}
+
+- (void)setAltitude:(NSNumber *)altitude {
+  objc_setAssociatedObject (self, &altitudeKey, altitude, OBJC_ASSOCIATION_RETAIN);
+}
+
+@end

--- a/GeoJSONSerialization/MKPolyline+Altitudes.h
+++ b/GeoJSONSerialization/MKPolyline+Altitudes.h
@@ -1,0 +1,31 @@
+// MKPolyline+EncodedString.h
+//
+// Copyright (c) 2016 Michele Noberasco
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <MapKit/MapKit.h>
+
+@interface MKPolyline (Altitudes)
+
++ (MKPolyline *)polylineWithCoordinates:(CLLocationCoordinate2D *)coords altitudes:(CLLocationDistance *)altitudes count:(NSUInteger)count;
+
+- (CLLocationDistance *)altitudes;
+
+@end

--- a/GeoJSONSerialization/MKPolyline+Altitudes.m
+++ b/GeoJSONSerialization/MKPolyline+Altitudes.m
@@ -1,0 +1,57 @@
+// MKPolyline+EncodedString.m
+//
+// Copyright (c) 2016 Michele Noberasco
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <objc/runtime.h>
+
+#import "MKPolyline+Altitudes.h"
+
+@implementation MKPolyline (Altitudes)
+
+static char altitudesKey;
+
++ (MKPolyline *)polylineWithCoordinates:(CLLocationCoordinate2D *)coords altitudes:(CLLocationDistance *)altitudes count:(NSUInteger)count {
+  MKPolyline *polyline = [MKPolyline polylineWithCoordinates:coords count:count];
+  
+  polyline.altitudes = altitudes;
+  
+  return polyline;
+}
+
+- (CLLocationDistance *)altitudes {
+  NSData *altitudes = objc_getAssociatedObject(self, &altitudesKey);
+  
+  return (CLLocationDistance *)altitudes.bytes;
+}
+
+- (void)setAltitudes:(CLLocationDistance *)altitudes {
+  NSData *data = nil;
+  
+  if (altitudes != nil) {
+    NSUInteger length = self.pointCount * sizeof(CLLocationDistance);
+    
+    data = [NSData dataWithBytes:altitudes length:length];
+  }
+  
+  objc_setAssociatedObject (self, &altitudesKey, data, OBJC_ASSOCIATION_RETAIN);
+}
+
+@end


### PR DESCRIPTION
This pull request adds ability to parse altitude information from GeoJSON encoded data. Basically is expects altitudes to be stored as the third field in coordinates. Results are stored directly into the relevant shape objects, my means of categories.
